### PR TITLE
Add sample implementation of using prefab-cloud-django

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 *.so
 
 # Distribution / packaging
+src/
 .Python
 build/
 develop-eggs/

--- a/.prefab.default.config.yaml
+++ b/.prefab.default.config.yaml
@@ -1,0 +1,5 @@
+log-level:
+  _: DEBUG
+  prefab:
+    views:
+      show: WARN

--- a/ADDING_PREFAB.md
+++ b/ADDING_PREFAB.md
@@ -1,0 +1,66 @@
+# Adding Prefab to a Django application
+
+## Install dependencies
+
+Add
+
+```python
+prefab-cloud-python==0.5.0
+```
+
+to your requirements. If you want to use prefab in template tags, you'll also need to add
+
+```python
+prefab-cloud-django==0.2.0
+```
+
+## Configure Prefab
+
+In your `settings.py`
+
+```
+import prefab_cloud_python as prefab
+
+options = prefab.Options(
+    api_key=YOUR_PREFAB_API_KEY,
+    ...
+)
+
+PREFAB = prefab.Client(options)
+LOGGER = PREFAB.logger
+```
+
+## Using Prefab
+
+Then, in your source files, you can use Prefab following its [documentation](https://docs.prefab.cloud/docs/python-sdk/python)
+
+```
+from django.conf import settings
+
+def your_method(...):
+    value = settings.PREFAB.get("your-config", default="whatever")
+    settings.LOGGER.info(f"got {value} for 'your-config'")
+```
+
+
+## Using Prefab template tags
+
+In your `views.py`
+
+```
+from prefab_cloud_python import Context
+
+def index(request):
+    context = Context({"user": {"name": "michael", "role": "developer"}})
+    return render(request, "prefab/index.html", {"context": context})
+```
+
+In `templates/index.html`
+
+```python
+{% load prefab_tags %}
+
+{% prefab_get "your-config" default="whatever" %}
+
+{% prefab_enabled "your-feature-flag" context=context %}
+```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+## Running the demo app
+
+### Configure env
+
+add a `.env` file with contents like
+
+```
+PREFAB_API_KEY="your key here"
+PREFAB_API_URL="https://api.staging-prefab.cloud"
+PREFAB_GRPC_URL="grpc.staging-prefab.cloud:443"
+PREFAB_LOG_CLIENT_BOOTSTRAP_LEVEL=DEBUG
+```
+### Install requirements
+
+Run
+```
+python -m pip install -r requirements.txt
+```
+
+This should install
+* `Django`
+* `django-environ` (for being able to load the .env file)
+* `prefab_cloud_python` (from Github + its dependencies)
+
+### Run the server
+
+Run
+```
+python manage.py runserver
+```
+
+### Test it out
+
+In your Prefab config, create values for `features.feature-1`, `config.config-1` with some lookup-key related rules
+
+Navigate to
+
+* `localhost:8000/prefab`
+* `localhost:8000/prefab/features.feature-1`
+* `localhost:8000/prefab/config.config-1`
+
+Confirm that you are seeing the correct values!

--- a/example_django/settings.py
+++ b/example_django/settings.py
@@ -11,10 +11,14 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
 from pathlib import Path
+import prefab_cloud_python as prefab
+import environ
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+environ.Env.read_env(os.path.join(BASE_DIR, ".env"))
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
@@ -32,6 +36,7 @@ ALLOWED_HOSTS = ["localhost"]
 
 INSTALLED_APPS = [
     "prefab.apps.PrefabConfig",
+    "prefab_cloud_django",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -106,7 +111,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = "UTC"
+TIME_ZONE = "US/Eastern"
 
 USE_I18N = True
 
@@ -122,3 +127,12 @@ STATIC_URL = "static/"
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# Prefab
+options = prefab.Options(
+    prefab_config_classpath_dir=".",
+    log_boundary=BASE_DIR,
+    log_prefix="berkowitz.django.test",
+)
+PREFAB = prefab.Client(options)
+LOGGER = PREFAB.logger

--- a/prefab/templates/prefab/index.html
+++ b/prefab/templates/prefab/index.html
@@ -1,1 +1,15 @@
+{% load prefab_tags %}
+
 <h1>Django Prefab Demo</h1>
+
+<p>
+<strong>features.feature-1</strong>: {% prefab_get "features.feature-1" context=context %}
+</p>
+
+<p>
+<strong>features.feature-1</strong>: {% prefab_enabled "features.feature-1" %}
+</p>
+
+<p>
+<strong>config.config-1</strong>: {% prefab_get "config.config-1" %}
+</p>

--- a/prefab/templates/prefab/show.html
+++ b/prefab/templates/prefab/show.html
@@ -1,1 +1,25 @@
+{% load prefab_tags %}
+
 <h1>Finding config for {{ key }}</h1>
+
+<p>
+<h2><strong>value:</strong>{% prefab_get key lookup_key=lookup_key default=default properties=properties %}</h2>
+</p>
+
+<p>
+  <strong>Lookup key:</strong>{{ lookup_key }}
+</p>
+
+<p>
+  <strong>default:</strong>{{ default }}
+</p>
+
+<p>
+  <strong>properties:</strong>
+  <ul>
+    {% for key, value in properties.items %}
+    <li>{{key}}: {{value}}</li>
+    {% endfor %}
+  </ul>
+</p>
+

--- a/prefab/urls.py
+++ b/prefab/urls.py
@@ -5,5 +5,5 @@ from . import views
 app_name = "prefab"
 urlpatterns = [
     path("", views.index, name="index"),
-    path("<slug:prefab_key>/", views.show, name="show")
+    path("<str:prefab_key>/", views.show, name="show")
 ]

--- a/prefab/views.py
+++ b/prefab/views.py
@@ -1,9 +1,27 @@
 from django.shortcuts import render
 
+from django.conf import settings
+
+from prefab_cloud_python import Context
+
 
 def index(request):
-    return render(request, "prefab/index.html")
+    settings.LOGGER.debug("SHOWN: debug")
+    settings.LOGGER.info("SHOWN: info")
+    settings.LOGGER.warn("SHOWN: warn")
+    settings.LOGGER.error("SHOWN: error")
+    settings.LOGGER.critical("SHOWN: critical")
+    context = Context({"michael": {"is_michael": True}})
+    return render(request, "prefab/index.html", {"prefab": settings.PREFAB, "context": context})
 
 
 def show(request, prefab_key):
-    return render(request, "prefab/show.html", {"key": prefab_key})
+    settings.LOGGER.debug("HIDDEN: debug")
+    settings.LOGGER.info("HIDDEN: info")
+    settings.LOGGER.warn("SHOWN: warn")
+    settings.LOGGER.error("SHOWN: error")
+    settings.LOGGER.critical("SHOWN: critical")
+    settings.LOGGER.error(request.GET)
+    lookup_key = request.GET.get("lookup_key")
+    default = request.GET.get("default")
+    return render(request, "prefab/show.html", {"key": prefab_key, "lookup_key": lookup_key, "default": default, "properties": {}})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Django==4.2
+django-environ==0.10.0
+prefab-cloud-python==0.3.3
+prefab-cloud-django==0.2.0


### PR DESCRIPTION
Add sample implementation of using prefab-cloud-django

* Add prefab libraries as requirements
* Configure Prefab client and logger in `settings.py`
* Show location-based logging examples in prefab views
* Add templates exercising the templatetags from prefab-cloud-django
